### PR TITLE
Fix stream stop deadlock and improve UX

### DIFF
--- a/dictation.py
+++ b/dictation.py
@@ -153,13 +153,29 @@ def transcribe_audio():
             logging.info(f"Long transcription ({duration_seconds:.1f}s) saved to transcript log")
 
         if text:
-            # Type the text directly using AppleScript (preserves clipboard)
-            # Escape quotes and backslashes for AppleScript
-            escaped_text = text.replace('\\', '\\\\').replace('"', '\\"')
+            # Use clipboard + paste to avoid triggering shortcuts
+            # Save current clipboard
+            import pyperclip
+            import time
+            old_clipboard = pyperclip.paste()
+
+            # Set text to clipboard
+            pyperclip.copy(text)
+
+            # Small delay to ensure clipboard is updated
+            time.sleep(0.05)
+
+            # Paste using Cmd+V
             paste_result = subprocess.run([
                 'osascript', '-e',
-                f'tell application "System Events" to keystroke "{escaped_text}"'
+                'tell application "System Events" to keystroke "v" using command down'
             ], capture_output=True, text=True)
+
+            # Wait for paste to complete before restoring clipboard
+            time.sleep(0.1)
+
+            # Restore old clipboard
+            pyperclip.copy(old_clipboard)
 
             if paste_result.returncode != 0:
                 logging.error(f"Paste failed: {paste_result.stderr}")


### PR DESCRIPTION
Critical fixes:
1. Use abort() instead of stop() to prevent deadlock
   - stream.stop() was blocking transcription thread
   - abort() terminates immediately without waiting for buffers

2. Consume Right Command events to prevent system shortcuts
   - Return None instead of passing event through
   - Prevents Cmd+T, Cmd+, etc when pressing during transcription

3. Add transcription status indicator
   - Change icon to 💭 (thinking) during transcription
   - Restore to 🎤 when done

4. Fix icon not restoring on early return
   - Wrap entire transcribe_audio in try/finally
   - Ensures icon always restored even on error/early exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)