### PR TITLE
Enable parallel chunk recording

### DIFF
--- a/dictation.py
+++ b/dictation.py
@@ -253,19 +253,8 @@ def state_manager():
                     threading.Thread(target=do_transcription, daemon=True).start()
                     logging.info(f"Transcription started for chunk {chunk_id}")
 
-                # Try to type any pending chunks that are ready (in order)
-                # Command was just released, so safe to type
-                typed_any = False
-                while next_chunk_to_type in pending_chunks:
-                    type_text(pending_chunks[next_chunk_to_type])
-                    del pending_chunks[next_chunk_to_type]
-                    next_chunk_to_type += 1
-                    typed_any = True
-
-                if typed_any:
-                    if app_instance:
-                        app_instance.title = "🎤"
-                    logging.info(f"Typed chunks up to {next_chunk_to_type - 1}")
+                # Pending chunks will be typed by CHUNK_DONE handler when safe
+                # (checking command_held and is_recording to avoid race conditions)
 
             # Handle CHUNK_DONE: A transcription finished
             elif isinstance(msg, tuple) and msg[0] == 'CHUNK_DONE':


### PR DESCRIPTION
## Summary

Users can now record multiple chunks by pressing/releasing Command multiple times. Each chunk transcribes in parallel, and all chunks type in the correct order.

### User Experience

**Before:** Press → speak → release → wait for transcription → press again

**After:** Press → speak → release → **press again immediately** → speak → release (first chunk types, then second)

### Key Changes

**Architecture:**
- 🏗️ Removed state machine (IDLE/RECORDING/TRANSCRIBING)
- 🎯 Flag-based tracking: `is_recording`, `command_held`, chunk IDs
- ⚡ Multiple transcriptions run in parallel

**Sequencing:**
- `next_chunk_to_record`: Assigns IDs to new recordings
- `next_chunk_to_type`: Ensures in-order typing  
- `pending_chunks`: Buffer of {chunk_id: text}

**Bug Fixes:**
- ✅ Fixed closure bug where chunk_id was captured incorrectly
- ✅ Chunks always type in recording order, even if transcriptions finish out-of-order

### Test Scenarios

- [x] Single chunk (works as before)
- [x] Two sequential chunks
- [x] Out-of-order transcription (long chunk, then short chunk)
- [x] Closure bug fixed (chunks have correct IDs)

### Known Limitation

⚠️ **Command-held during typing:** If user presses Command while text is typing, shortcuts can trigger. This will be addressed in a **separate PR** focusing solely on that issue (using event tap to block Command during typing).

This PR intentionally keeps chunking separate from the Command-blocking feature for cleaner review.

### Future Work

This architecture makes it trivial to add:
- Automatic pause detection
- Real-time incremental typing
- Configurable chunk triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)